### PR TITLE
Move dependency paths to a folder next to repo

### DIFF
--- a/Source/ZLevels/ZLevels/ZLevels.csproj
+++ b/Source/ZLevels/ZLevels/ZLevels.csproj
@@ -32,14 +32,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\SourceDLLs\0Harmony.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="0MultiplayerAPI">
-      <HintPath>..\SourceDLLs\0MultiplayerAPI.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\0MultiplayerAPI.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\SourceDLLs\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -51,251 +51,251 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\SourceDLLs\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\SourceDLLs\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AccessibilityModule">
-      <HintPath>..\SourceDLLs\UnityEngine.AccessibilityModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.AccessibilityModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AIModule">
-      <HintPath>..\SourceDLLs\UnityEngine.AIModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.AIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AndroidJNIModule">
-      <HintPath>..\SourceDLLs\UnityEngine.AndroidJNIModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.AndroidJNIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\SourceDLLs\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.AnimationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ARModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ARModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ARModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\SourceDLLs\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\SourceDLLs\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.AudioModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClothModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ClothModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ClothModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClusterInputModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ClusterInputModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ClusterInputModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClusterRendererModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ClusterRendererModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ClusterRendererModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\SourceDLLs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CrashReportingModule">
-      <HintPath>..\SourceDLLs\UnityEngine.CrashReportingModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.CrashReportingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.DirectorModule">
-      <HintPath>..\SourceDLLs\UnityEngine.DirectorModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.DirectorModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.DSPGraphModule">
-      <HintPath>..\SourceDLLs\UnityEngine.DSPGraphModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.DSPGraphModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.FileSystemHttpModule">
-      <HintPath>..\SourceDLLs\UnityEngine.FileSystemHttpModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.FileSystemHttpModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.GameCenterModule">
-      <HintPath>..\SourceDLLs\UnityEngine.GameCenterModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.GameCenterModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.GridModule">
-      <HintPath>..\SourceDLLs\UnityEngine.GridModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.GridModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.HotReloadModule">
-      <HintPath>..\SourceDLLs\UnityEngine.HotReloadModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.HotReloadModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\SourceDLLs\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\SourceDLLs\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputModule">
-      <HintPath>..\SourceDLLs\UnityEngine.InputModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.InputModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule">
-      <HintPath>..\SourceDLLs\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.JSONSerializeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.LocalizationModule">
-      <HintPath>..\SourceDLLs\UnityEngine.LocalizationModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.LocalizationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ParticleSystemModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PerformanceReportingModule">
-      <HintPath>..\SourceDLLs\UnityEngine.PerformanceReportingModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.PerformanceReportingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>..\SourceDLLs\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.Physics2DModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\SourceDLLs\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ProfilerModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ProfilerModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ProfilerModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ScreenCaptureModule">
-      <HintPath>..\SourceDLLs\UnityEngine.ScreenCaptureModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.ScreenCaptureModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SharedInternalsModule">
-      <HintPath>..\SourceDLLs\UnityEngine.SharedInternalsModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.SharedInternalsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SpriteMaskModule">
-      <HintPath>..\SourceDLLs\UnityEngine.SpriteMaskModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.SpriteMaskModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SpriteShapeModule">
-      <HintPath>..\SourceDLLs\UnityEngine.SpriteShapeModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.SpriteShapeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.StreamingModule">
-      <HintPath>..\SourceDLLs\UnityEngine.StreamingModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.StreamingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SubstanceModule">
-      <HintPath>..\SourceDLLs\UnityEngine.SubstanceModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.SubstanceModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TerrainModule">
-      <HintPath>..\SourceDLLs\UnityEngine.TerrainModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.TerrainModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TerrainPhysicsModule">
-      <HintPath>..\SourceDLLs\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.TerrainPhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextCoreModule">
-      <HintPath>..\SourceDLLs\UnityEngine.TextCoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.TextCoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\SourceDLLs\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TilemapModule">
-      <HintPath>..\SourceDLLs\UnityEngine.TilemapModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.TilemapModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TLSModule">
-      <HintPath>..\SourceDLLs\UnityEngine.TLSModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.TLSModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\SourceDLLs\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UIElementsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UmbraModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UmbraModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UmbraModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UNETModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UNETModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UNETModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityAnalyticsModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityAnalyticsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityConnectModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityConnectModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityConnectModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityTestProtocolModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityTestProtocolModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityWebRequestModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VehiclesModule">
-      <HintPath>..\SourceDLLs\UnityEngine.VehiclesModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.VehiclesModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VFXModule">
-      <HintPath>..\SourceDLLs\UnityEngine.VFXModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.VFXModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VideoModule">
-      <HintPath>..\SourceDLLs\UnityEngine.VideoModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.VideoModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VRModule">
-      <HintPath>..\SourceDLLs\UnityEngine.VRModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.VRModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.WindModule">
-      <HintPath>..\SourceDLLs\UnityEngine.WindModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.WindModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
-      <HintPath>..\SourceDLLs\UnityEngine.XRModule.dll</HintPath>
+      <HintPath>..\..\..\..\SourceDLLs\UnityEngine.XRModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/ZLevels/ZLevels/ZLevels.csproj
+++ b/Source/ZLevels/ZLevels/ZLevels.csproj
@@ -32,14 +32,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\0Harmony.dll</HintPath>
+      <HintPath>..\SourceDLLs\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="0MultiplayerAPI">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\0MultiplayerAPI.dll</HintPath>
+      <HintPath>..\SourceDLLs\0MultiplayerAPI.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\SourceDLLs\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -51,251 +51,251 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>..\SourceDLLs\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AccessibilityModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.AccessibilityModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.AccessibilityModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AIModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.AIModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.AIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AndroidJNIModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.AndroidJNIModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.AndroidJNIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.AnimationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ARModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ARModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ARModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.AudioModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClothModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ClothModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ClothModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClusterInputModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ClusterInputModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ClusterInputModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClusterRendererModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ClusterRendererModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ClusterRendererModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CrashReportingModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.CrashReportingModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.CrashReportingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.DirectorModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.DirectorModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.DirectorModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.DSPGraphModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.DSPGraphModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.DSPGraphModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.FileSystemHttpModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.FileSystemHttpModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.FileSystemHttpModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.GameCenterModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.GameCenterModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.GameCenterModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.GridModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.GridModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.GridModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.HotReloadModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.HotReloadModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.HotReloadModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.InputModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.InputModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.JSONSerializeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.LocalizationModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.LocalizationModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.LocalizationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ParticleSystemModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PerformanceReportingModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.PerformanceReportingModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.PerformanceReportingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.Physics2DModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ProfilerModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ProfilerModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ProfilerModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ScreenCaptureModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.ScreenCaptureModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.ScreenCaptureModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SharedInternalsModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.SharedInternalsModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.SharedInternalsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SpriteMaskModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.SpriteMaskModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.SpriteMaskModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SpriteShapeModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.SpriteShapeModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.SpriteShapeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.StreamingModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.StreamingModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.StreamingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SubstanceModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.SubstanceModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.SubstanceModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TerrainModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.TerrainModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.TerrainModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TerrainPhysicsModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.TerrainPhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextCoreModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.TextCoreModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.TextCoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TilemapModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.TilemapModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.TilemapModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TLSModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.TLSModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.TLSModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UIElementsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UmbraModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UmbraModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UmbraModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UNETModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UNETModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UNETModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityAnalyticsModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityAnalyticsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityConnectModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityConnectModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityConnectModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityTestProtocolModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityTestProtocolModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VehiclesModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.VehiclesModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.VehiclesModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VFXModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.VFXModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.VFXModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VideoModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.VideoModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.VideoModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VRModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.VRModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.VRModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.WindModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.WindModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.WindModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
-      <HintPath>..\..\..\..\..\..\..\Files\devmods\SourceDLLs\UnityEngine.XRModule.dll</HintPath>
+      <HintPath>..\SourceDLLs\UnityEngine.XRModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
After this change dependency dll's are expected to be found in a "SourceDLLs" folder next to the cloned repo.
The reason for this change is to make setting up the project and developing easier.