### PR TITLE
Fixes pawn getting stuck when sleeping on the ground

### DIFF
--- a/Source/ZLevels/ZLevels/HarmonyPatches/JobPatches.cs
+++ b/Source/ZLevels/ZLevels/HarmonyPatches/JobPatches.cs
@@ -839,6 +839,9 @@ namespace ZLevels
             private static IntVec3 FindGroundSleepSpotFor(Pawn pawn)
             {
                 Map map = pawn.Map;
+                ZUtils.currentLookedIntoMap = map;
+                //ZUtils.ZTracker.jobTracker.TryGetValue( pawn, out var jobTracker );
+                //var localCellMap = jobTracker?.lookedAtLocalCellMap;
                 for (int i = 0; i < 2; i++)
                 {
                     int radius = (i == 0) ? 4 : 12;


### PR DESCRIPTION
When looking for a random spot to sleep, we have to record the map of the chosen spot, otherwise a random one is taken and the spot is most likely invalid.